### PR TITLE
Feature/errors in container remake

### DIFF
--- a/src/Core/src/Exception/Container/ContainerException.php
+++ b/src/Core/src/Exception/Container/ContainerException.php
@@ -17,7 +17,7 @@ class ContainerException extends RuntimeException implements ContainerExceptionI
         string $message = '',
         int $code = 0,
         ?\Throwable $previous = null,
-        protected ?Tracer $tracer = null
+        protected ?Tracer $tracer = null,
     ) {
         parent::__construct($tracer !== null ? $message . PHP_EOL . $tracer : $message, $code, $previous);
 

--- a/src/Core/src/Exception/Container/ContainerException.php
+++ b/src/Core/src/Exception/Container/ContainerException.php
@@ -6,21 +6,10 @@ namespace Spiral\Core\Exception\Container;
 
 use Psr\Container\ContainerExceptionInterface;
 use Spiral\Core\Exception\RuntimeException;
-use Spiral\Core\Internal\Tracer;
 
 /**
  * Something inside container.
  */
 class ContainerException extends RuntimeException implements ContainerExceptionInterface
 {
-    public function __construct(
-        string $message = '',
-        int $code = 0,
-        ?\Throwable $previous = null,
-        protected ?Tracer $tracer = null,
-    ) {
-        parent::__construct($tracer !== null ? $message . PHP_EOL . $tracer : $message, $code, $previous);
-
-        $tracer?->clean();
-    }
 }

--- a/src/Core/src/Exception/Resolver/InvalidArgumentException.php
+++ b/src/Core/src/Exception/Resolver/InvalidArgumentException.php
@@ -14,7 +14,7 @@ final class InvalidArgumentException extends ValidationException
         \ReflectionFunctionAbstract $reflection,
         private readonly string $parameter
     ) {
-        $pattern = "Invalid argument value type for the `$parameter` parameter when validating arguments for `%s` %s.";
+        $pattern = "Invalid argument value type for the `$parameter` parameter when validating arguments for `%s`.";
         parent::__construct($this->renderFunctionAndParameter($reflection, $pattern));
     }
 

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -250,7 +250,8 @@ final class Factory implements FactoryInterface
             } catch (ValidationException $e) {
                 throw new ContainerException(
                     $this->tracer->combineTraceMessage(
-                        \sprintf('Can\'t resolve `%s`. %s',
+                        \sprintf(
+                            'Can\'t resolve `%s`. %s',
                             $this->tracer->getRootAlias(),
                             $e->getMessage()
                         )

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -14,6 +14,7 @@ use Spiral\Core\Exception\Container\ContainerException;
 use Spiral\Core\Exception\Container\InjectionException;
 use Spiral\Core\Exception\Container\NotCallableException;
 use Spiral\Core\Exception\Container\NotFoundException;
+use Spiral\Core\Exception\Resolver\ValidationException;
 use Spiral\Core\Exception\Resolver\WrongTypeException;
 use Spiral\Core\FactoryInterface;
 use Spiral\Core\InvokerInterface;
@@ -54,7 +55,7 @@ final class Factory implements FactoryInterface
     public function make(string $alias, array $parameters = [], string $context = null): mixed
     {
         if (!isset($this->state->bindings[$alias])) {
-            $this->tracer->push($alias, ['source' => 'autowiring', 'context' => $context], true);
+            $this->tracer->push($alias, true, source: 'autowiring', context: $context);
             try {
                 //No direct instructions how to construct class, make is automatically
                 return $this->autowire($alias, $parameters, $context);
@@ -65,19 +66,31 @@ final class Factory implements FactoryInterface
 
         $binding = $this->state->bindings[$alias];
         try {
-            $this->tracer->push($alias, ['source' => 'binding', 'binding' => $binding, 'context' => $context], false);
+            $this->tracer->push($alias, false, source: 'binding', binding: $binding, context: $context);
 
             if (\is_object($binding)) {
                 if ($binding::class === WeakReference::class) {
                     if ($binding->get() === null && \class_exists($alias)) {
-                        $object = $this->createInstance($alias, $parameters, $context);
-                        $binding = $this->state->bindings[$alias] = WeakReference::create($object);
+                        try {
+                            $this->tracer->push($alias, false, source: 'WeakReference', context: $context);
+                            $object = $this->createInstance($alias, $parameters, $context);
+                            $binding = $this->state->bindings[$alias] = WeakReference::create($object);
+                        } catch (\Throwable) {
+                            throw new ContainerException($this->tracer->combineTraceMessage(\sprintf(
+                                'Can\'t resolve `%s`: can\'t instantiate `%s` from WeakReference binding.',
+                                $this->tracer->getRootAlias(),
+                                $alias,
+                            )));
+                        } finally {
+                            $this->tracer->pop();
+                        }
                     }
                     return $binding->get();
                 }
                 //When binding is instance, assuming singleton
                 return $binding;
             }
+            $this->tracer->push($alias, false, source: 'binding', binding: $binding, context: $context);
 
             if (\is_string($binding)) {
                 //Binding is pointing to something else
@@ -117,7 +130,7 @@ final class Factory implements FactoryInterface
     private function autowire(string $class, array $parameters, string $context = null): object
     {
         if (!\class_exists($class) && !isset($this->state->injectors[$class])) {
-            throw new NotFoundException($this->tracer->getExceptionMessage(\sprintf(
+            throw new NotFoundException($this->tracer->combineTraceMessage(\sprintf(
                 'Can\'t resolve `%s`: undefined class or binding `%s`.',
                 $this->tracer->getRootAlias(),
                 $class
@@ -156,7 +169,7 @@ final class Factory implements FactoryInterface
             return $this->invoker->invoke($target, $parameters);
         } catch (NotCallableException $e) {
             throw new ContainerException(
-                $this->tracer->getExceptionMessage(\sprintf('Invalid binding for `%s`.', $alias)),
+                $this->tracer->combineTraceMessage(\sprintf('Invalid binding for `%s`.', $alias)),
                 $e->getCode(),
                 $e,
             );
@@ -225,7 +238,7 @@ final class Factory implements FactoryInterface
                 default => 'Class',
             };
             throw new ContainerException(
-                $this->tracer->getExceptionMessage(\sprintf('%s `%s` can not be constructed.', $itIs, $class)),
+                $this->tracer->combineTraceMessage(\sprintf('%s `%s` can not be constructed.', $itIs, $class)),
             );
         }
 
@@ -233,8 +246,20 @@ final class Factory implements FactoryInterface
 
         if ($constructor !== null) {
             try {
+                $arguments = $this->resolver->resolveArguments($constructor, $parameters);
+            } catch (ValidationException $e) {
+                throw new ContainerException(
+                    $this->tracer->combineTraceMessage(
+                        \sprintf('Can\'t resolve `%s`. %s',
+                            $this->tracer->getRootAlias(),
+                            $e->getMessage()
+                        )
+                    ),
+                );
+            }
+            try {
                 // Using constructor with resolved arguments
-                $instance = new $class(...$this->resolver->resolveArguments($constructor, $parameters));
+                $instance = new $class(...$arguments);
             } catch (\TypeError $e) {
                 throw new WrongTypeException($constructor, $e);
             }

--- a/src/Core/src/Internal/Factory.php
+++ b/src/Core/src/Internal/Factory.php
@@ -55,12 +55,12 @@ final class Factory implements FactoryInterface
     public function make(string $alias, array $parameters = [], string $context = null): mixed
     {
         if (!isset($this->state->bindings[$alias])) {
-            $this->tracer->push($alias, true, source: 'autowiring', context: $context);
+            $this->tracer->push($alias, false, source: 'autowiring', context: $context);
             try {
                 //No direct instructions how to construct class, make is automatically
                 return $this->autowire($alias, $parameters, $context);
             } finally {
-                $this->tracer->pop(true);
+                $this->tracer->pop(false);
             }
         }
 

--- a/src/Core/src/Internal/Trace.php
+++ b/src/Core/src/Internal/Trace.php
@@ -11,19 +11,12 @@ final class Trace implements \Stringable
 {
     public function __construct(
         public readonly string $alias,
-        public readonly string $information,
-        public ?string $context = null
+        public array $info,
     ) {
-        $this->context ??= '-';
     }
 
     public function __toString(): string
     {
-        $result = [];
-        $result[] = '- ' . $this->alias;
-        $result[] = '    Info: ' . $this->information;
-        $result[] = '    Context: ' . $this->context;
-
-        return \implode(PHP_EOL, $result);
+        return $this->alias . '  ' . \json_encode($this->info, JSON_PRETTY_PRINT);
     }
 }

--- a/src/Core/src/Internal/Tracer.php
+++ b/src/Core/src/Internal/Tracer.php
@@ -26,12 +26,12 @@ final class Tracer implements \Stringable
      * @param bool $lastBlock Generate trace list only for last block
      * @param bool $clear Remove touched trace list
      */
-    public function getExceptionMessage(string $header, bool $lastBlock = false, bool $clear = false): string
+    public function combineTraceMessage(string $header, bool $lastBlock = false, bool $clear = false): string
     {
         return "$header\n$this";
     }
 
-    public function push(string $alias, array $details, bool $nextLevel = false): void
+    public function push(string $alias, bool $nextLevel = false, mixed ...$details): void
     {
         $trace = new Trace($alias, $details);
         if ($nextLevel || $this->traces === []) {
@@ -61,11 +61,6 @@ final class Tracer implements \Stringable
     public function getRootAlias(): string
     {
         return $this->traces[0][0]->alias;
-    }
-
-    public function clean(): void
-    {
-        $this->traces = [];
     }
 
     /**

--- a/src/Core/src/Internal/Tracer.php
+++ b/src/Core/src/Internal/Tracer.php
@@ -18,7 +18,7 @@ final class Tracer implements \Stringable
 
     public function __toString(): string
     {
-        return $this->traces === [] ? '' : 'Container trace list:' . PHP_EOL . $this->renderTraceList($this->traces);
+        return $this->traces === [] ? '' : "Container trace list:\n" . $this->renderTraceList($this->traces);
     }
 
     /**
@@ -60,7 +60,7 @@ final class Tracer implements \Stringable
 
     public function getRootAlias(): string
     {
-        return $this->traces[0][0]->alias;
+        return $this->traces[0][0]->alias ?? '';
     }
 
     /**
@@ -73,7 +73,7 @@ final class Tracer implements \Stringable
         foreach ($blocks as $block) {
             \array_push($result, ...$this->blockToStringList($block, $i++));
         }
-        return \implode(PHP_EOL, $result);
+        return \implode("\n", $result);
     }
 
     /**

--- a/src/Core/src/Internal/Tracer.php
+++ b/src/Core/src/Internal/Tracer.php
@@ -28,8 +28,6 @@ final class Tracer implements \Stringable
      */
     public function getExceptionMessage(string $header, bool $lastBlock = false, bool $clear = false): string
     {
-
-
         return "$header\n$this";
     }
 

--- a/src/Core/tests/AutowireTest.php
+++ b/src/Core/tests/AutowireTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Core;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\Core\Container;
+use Spiral\Core\Exception\Container\ContainerException;
 use Spiral\Core\Exception\Container\NotFoundException;
 use Spiral\Core\Exception\Resolver\ArgumentResolvingException;
 use Spiral\Core\Exception\Resolver\InvalidArgumentException;
@@ -438,7 +439,8 @@ class AutowireTest extends TestCase
 
     private function expectValidationException(string $parameter): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        // $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ContainerException::class);
         $this->expectExceptionMessage(
             "Invalid argument value type for the `$parameter` parameter when validating arguments"
         );

--- a/src/Core/tests/ExceptionsTest.php
+++ b/src/Core/tests/ExceptionsTest.php
@@ -73,7 +73,10 @@ class ExceptionsTest extends TestCase
         $this->assertSame('param', $e->getParameter()->getName());
     }
 
-    public function testExceptionTraceWithContainerInside(): void
+    /**
+     * Broken dependency in a constructor signature.
+     */
+    public function testExceptionTraceWithInvalidDependencyInSignature(): void
     {
         $container = new Container();
 

--- a/src/Core/tests/ExceptionsTest.php
+++ b/src/Core/tests/ExceptionsTest.php
@@ -92,9 +92,9 @@ class ExceptionsTest extends TestCase
               source: 'binding'
               binding: 'Spiral\Core\Container'
               context: 'container'
-              - Spiral\Tests\Core\Fixtures\InvalidClass
-                source: 'autowiring'
-                context: 'class'
+            - Spiral\Tests\Core\Fixtures\InvalidClass
+              source: 'autowiring'
+              context: 'class'
             MARKDOWN,
         );
 
@@ -131,9 +131,9 @@ class ExceptionsTest extends TestCase
             - Spiral\Tests\Core\Fixtures\ClassWithUndefinedDependency
               source: 'autowiring'
               context: NULL
-              - Spiral\Tests\Core\Fixtures\InvalidClass
-                source: 'autowiring'
-                context: 'class'
+            - Spiral\Tests\Core\Fixtures\InvalidClass
+              source: 'autowiring'
+              context: 'class'
             MARKDOWN
         ];
         yield [
@@ -170,9 +170,9 @@ class ExceptionsTest extends TestCase
               source: 'binding'
               binding: 'Spiral\Tests\Core\Fixtures\WithPrivateConstructor'
               context: 'class'
-              - Spiral\Tests\Core\Fixtures\WithPrivateConstructor
-                source: 'autowiring'
-                context: 'class'
+            - Spiral\Tests\Core\Fixtures\WithPrivateConstructor
+              source: 'autowiring'
+              context: 'class'
             MARKDOWN
         ];
         yield [


### PR DESCRIPTION
The `ContainerException` now doesn't know about internal Tracer.
Also we have more control over traces:
 - dynamic context
 - subitems in stack list

Also we need more tests. For example: do container->get twice to detect stacktrace is clear after the first exception